### PR TITLE
Fix all deprecation warnings but one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,9 @@
 name = "rust-raytracer"
 version = "0.1.0"
 dependencies = [
- "rustc-serialize 0.2.11 (git+http://github.com/rust-lang/rustc-serialize)",
- "time 0.1.15 (git+http://github.com/rust-lang/time)",
+ "rand 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -17,14 +18,28 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "log"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-serialize"
-version = "0.2.11"
-source = "git+http://github.com/rust-lang/rustc-serialize#a281f34a5f231b1bb6ea95944c60370d5bfafbe8"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "time"
 version = "0.1.15"
-source = "git+http://github.com/rust-lang/time#432268ef21eeb34c44a97f9294f8e2d9c94c795b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ authors = [
     "stacey.ell@gmail.com"
 ]
 
-[dependencies.time]
-git = "http://github.com/rust-lang/time"
-
-[dependencies.rustc-serialize]
-git = "http://github.com/rust-lang/rustc-serialize"
+[dependencies]
+time = "*"
+rustc-serialize = "*"
+rand = "*"

--- a/src/light/lights/spherelight.rs
+++ b/src/light/lights/spherelight.rs
@@ -1,4 +1,4 @@
-use std::rand::{thread_rng, Rng};
+use rand::{thread_rng, Rng};
 use light::light::Light;
 use vec3::Vec3;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,17 @@
-#![feature(box_syntax, collections, core, io, os, path, rand, slicing_syntax, std_misc)]
+#![feature(box_syntax, collections, core, env, io, os, path, slicing_syntax, std_misc)]
 #![deny(unused_imports)]
 
-extern crate time;
+extern crate rand;
 extern crate "rustc-serialize" as rustc_serialize;
+extern crate time;
+
 
 use scene::{Camera, Scene};
 
 use std::old_io::File;
 use std::old_io;
 use std::os;
+use std::env;
 use std::sync::Arc;
 use rustc_serialize::json;
 use rustc_serialize::json::DecoderError::MissingFieldError;
@@ -178,7 +181,7 @@ fn main() {
             error_str.push_str("\n");
             let mut stderr = old_io::stderr();
             assert!(stderr.write_all(error_str.as_bytes()).is_ok());
-            os::set_exit_status(1);
+            env::set_exit_status(1);
             return
         }
     };
@@ -188,7 +191,7 @@ fn main() {
         Err(err) => {
             let mut stderr = old_io::stderr();
             assert!(stderr.write_all(format!("{}\n", err).as_bytes()).is_ok());
-            os::set_exit_status(1);
+            env::set_exit_status(1);
             return
         }
     };
@@ -197,7 +200,7 @@ fn main() {
         Err(err) => {
             let mut stderr = old_io::stderr();
             assert!(stderr.write_all(format!("{}\n", err).as_bytes()).is_ok());
-            os::set_exit_status(1);
+            env::set_exit_status(1);
             return
         }
     };
@@ -215,7 +218,7 @@ fn main() {
                 }
             };
             assert!(stderr.write_all(msg.as_bytes()).is_ok());
-            os::set_exit_status(1);
+            env::set_exit_status(1);
             return
         }
     };
@@ -229,7 +232,7 @@ fn main() {
             let mut stderr = old_io::stderr();
             let msg = format!("unknown scene ``{}''\n", config.name);
             assert!(stderr.write_all(msg.as_bytes()).is_ok());
-            os::set_exit_status(1);
+            env::set_exit_status(1);
             return
         }
     };

--- a/src/raytracer/renderer.rs
+++ b/src/raytracer/renderer.rs
@@ -5,11 +5,11 @@ use scene::{Camera, Scene};
 use std::iter::range;
 use std::num::Float;
 use std::ops::Deref;
-use std::rand::{thread_rng, Rng, SeedableRng, Isaac64Rng};
 use std::sync::Arc;
 use std::sync::mpsc::channel;
 use std::sync::TaskPool;
 use vec3::Vec3;
+use rand::{thread_rng, Rng, SeedableRng, Isaac64Rng};
 
 pub static EPSILON: f64 = ::std::f64::EPSILON * 10000.0;
 


### PR DESCRIPTION
os::args() -> env::args() switches to OsString which covers
cross-platform compatibility much better, but I will defer
work on it for now.