### PR TITLE
Allow decoding of pngs directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.0"
 dependencies = [
  "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -36,6 +37,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "png"
+version = "0.1.0"
+source = "git+https://github.com/servo/rust-png#1c8dacff1115bf7597bd72281b6a4f135634c679"
+dependencies = [
+ "gcc 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png-sys 1.6.16 (git+https://github.com/servo/rust-png)",
+]
+
+[[package]]
+name = "png-sys"
+version = "1.6.16"
+source = "git+https://github.com/servo/rust-png#1c8dacff1115bf7597bd72281b6a4f135634c679"
 
 [[package]]
 name = "rand"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ rand = "*"
 rustc-serialize = "*"
 threadpool = "*"
 time = "*"
+
+[dependencies.png]
+git = "https://github.com/servo/rust-png"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(collections, convert, core, exit_status, float_consts, semaphore, slice_extras, std_misc, vec_push_all)]
+#![feature(convert, float_consts, semaphore, slice_extras, vec_push_all)]
 #![deny(unused_imports)]
 
 extern crate num;
@@ -13,6 +13,7 @@ use scene::{Camera, Scene};
 use std::fs::File;
 use std::io::{self, Read, Write};
 use std::env;
+use std::process;
 use std::sync::Arc;
 use rustc_serialize::json;
 use rustc_serialize::json::DecoderError::MissingFieldError;
@@ -175,24 +176,21 @@ fn main() {
         Ok(program_args) => program_args,
         Err(error_str) => {
             write!(&mut io::stderr(), "{}\n", error_str).unwrap();
-            env::set_exit_status(1);
-            return
+            process::exit(1);
         }
     };
     let mut file_handle = match File::open(&program_args.config_file) {
         Ok(file) => file,
         Err(err) => {
             write!(&mut io::stderr(), "{}\n", err).unwrap();
-            env::set_exit_status(1);
-            return
+            process::exit(1);
         }
     };
 
     let mut json_data = String::new();
     if let Err(ref err) = file_handle.read_to_string(&mut json_data) {
         write!(&mut io::stderr(), "{}\n", err).unwrap();
-        env::set_exit_status(1);
-        return
+        process::exit(1);
     }
 
     let config: SceneConfig = match json::decode(&json_data) {
@@ -207,8 +205,7 @@ fn main() {
                 }
             };
             write!(&mut io::stderr(), "{}\n", msg).unwrap();
-            env::set_exit_status(1);
-            return
+            process::exit(1);
         }
     };
 
@@ -219,8 +216,7 @@ fn main() {
         Some(pair) => pair,
         None => {
             write!(&mut io::stderr(), "unknown scene ``{}''\n", config.name).unwrap();
-            env::set_exit_status(1);
-            return
+            process::exit(1);
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(collections, convert, core, exit_status, std_misc)]
+#![feature(collections, convert, core, exit_status, float_consts, semaphore, slice_extras, std_misc, vec_push_all)]
 #![deny(unused_imports)]
 
 extern crate num;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ extern crate rand;
 extern crate rustc_serialize;
 extern crate threadpool;
 extern crate time;
+extern crate png;
 
 use scene::{Camera, Scene};
 

--- a/src/material/textures/imagetexture.rs
+++ b/src/material/textures/imagetexture.rs
@@ -11,7 +11,7 @@ pub struct ImageTexture {
 impl ImageTexture {
     #[allow(dead_code)]
     pub fn load(filename: &str) -> ImageTexture {
-        ImageTexture { image: ::util::import::from_ppm(filename) }
+        ImageTexture { image: ::util::import::from_png(filename).unwrap() }
     }
 
     // Alias, used by skybox sampling. This is needed because we aren't storing the skybox

--- a/src/my_scene/bunny.rs
+++ b/src/my_scene/bunny.rs
@@ -49,12 +49,12 @@ pub fn get_scene() -> Scene {
         octree: octree,
         background: Vec3 { x: 0.3, y: 0.5, z: 0.8 },
         skybox: Some(CubeMap::load(
-            "./docs/assets/textures/skyboxes/storm_y_up/left.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/right.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/down.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/up.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/front.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/back.ppm"
+            "./docs/assets/textures/skyboxes/storm_y_up/left.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/right.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/down.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/up.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/front.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/back.png"
         ))
     }
 }

--- a/src/my_scene/heptoroid.rs
+++ b/src/my_scene/heptoroid.rs
@@ -48,12 +48,12 @@ pub fn get_scene(material_option: &str) -> Scene {
         octree: octree,
         background: Vec3 { x: 0.84, y: 0.34, z: 0.0 },
         skybox: Some(CubeMap::load(
-            "./docs/assets/textures/skyboxes/miramar_y_up/left.ppm",
-            "./docs/assets/textures/skyboxes/miramar_y_up/right.ppm",
-            "./docs/assets/textures/skyboxes/miramar_y_up/down.ppm",
-            "./docs/assets/textures/skyboxes/miramar_y_up/up.ppm",
-            "./docs/assets/textures/skyboxes/miramar_y_up/front.ppm",
-            "./docs/assets/textures/skyboxes/miramar_y_up/back.ppm"
+            "./docs/assets/textures/skyboxes/miramar_y_up/left.png",
+            "./docs/assets/textures/skyboxes/miramar_y_up/right.png",
+            "./docs/assets/textures/skyboxes/miramar_y_up/down.png",
+            "./docs/assets/textures/skyboxes/miramar_y_up/up.png",
+            "./docs/assets/textures/skyboxes/miramar_y_up/front.png",
+            "./docs/assets/textures/skyboxes/miramar_y_up/back.png"
         ))
     }
 }

--- a/src/my_scene/lucy.rs
+++ b/src/my_scene/lucy.rs
@@ -43,12 +43,12 @@ pub fn get_scene() -> Scene {
         octree: octree,
         background: Vec3 { x: 0.84, y: 0.34, z: 0.0 },
         skybox: Some(CubeMap::load(
-            "./docs/assets/textures/skyboxes/storm_y_up/left.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/right.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/down.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/up.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/front.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/back.ppm"
+            "./docs/assets/textures/skyboxes/storm_y_up/left.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/right.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/down.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/up.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/front.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/back.png"
         ))
     }
 }

--- a/src/my_scene/sphere.rs
+++ b/src/my_scene/sphere.rs
@@ -94,12 +94,12 @@ pub fn get_scene() -> Scene {
         background: Vec3 { x: 0.3, y: 0.5, z: 0.8 },
         octree: octree,
         skybox: Some(CubeMap::load(
-            "./docs/assets/textures/skyboxes/storm_y_up/left.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/right.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/down.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/up.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/front.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/back.ppm"
+            "./docs/assets/textures/skyboxes/storm_y_up/left.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/right.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/down.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/up.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/front.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/back.png"
         ))
     }
 }

--- a/src/my_scene/sponza.rs
+++ b/src/my_scene/sponza.rs
@@ -58,12 +58,12 @@ pub fn get_scene() -> Scene {
         octree: octree,
         background: Vec3 { x: 0.84, y: 0.34, z: 0.0 },
         skybox: Some(CubeMap::load(
-            "./docs/assets/textures/skyboxes/storm_y_up/left.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/right.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/down.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/up.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/front.ppm",
-            "./docs/assets/textures/skyboxes/storm_y_up/back.ppm"
+            "./docs/assets/textures/skyboxes/storm_y_up/left.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/right.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/down.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/up.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/front.png",
+            "./docs/assets/textures/skyboxes/storm_y_up/back.png"
         ))
     }
 }

--- a/src/my_scene/tachikoma.rs
+++ b/src/my_scene/tachikoma.rs
@@ -46,12 +46,12 @@ pub fn get_scene() -> Scene {
         background: Vec3 { x: 0.2, y: 0.2, z: 0.2 },
         // skybox: None
         skybox: Some(CubeMap::load(
-            "./docs/assets/textures/skyboxes/city_y_up/left.ppm",
-            "./docs/assets/textures/skyboxes/city_y_up/right.ppm",
-            "./docs/assets/textures/skyboxes/city_y_up/down.ppm",
-            "./docs/assets/textures/skyboxes/city_y_up/up.ppm",
-            "./docs/assets/textures/skyboxes/city_y_up/front.ppm",
-            "./docs/assets/textures/skyboxes/city_y_up/back.ppm"
+            "./docs/assets/textures/skyboxes/city_y_up/left.png",
+            "./docs/assets/textures/skyboxes/city_y_up/right.png",
+            "./docs/assets/textures/skyboxes/city_y_up/down.png",
+            "./docs/assets/textures/skyboxes/city_y_up/up.png",
+            "./docs/assets/textures/skyboxes/city_y_up/front.png",
+            "./docs/assets/textures/skyboxes/city_y_up/back.png"
         ))
     }
 }

--- a/src/my_scene/teapot.rs
+++ b/src/my_scene/teapot.rs
@@ -50,12 +50,12 @@ pub fn get_teapot_scene() -> Scene {
         octree: octree,
         background: Vec3 { x: 0.3, y: 0.5, z: 0.8 },
         skybox: Some(CubeMap::load(
-            "./docs/assets/textures/skyboxes/miramar_y_up/left.ppm",
-            "./docs/assets/textures/skyboxes/miramar_y_up/right.ppm",
-            "./docs/assets/textures/skyboxes/miramar_y_up/down.ppm",
-            "./docs/assets/textures/skyboxes/miramar_y_up/up.ppm",
-            "./docs/assets/textures/skyboxes/miramar_y_up/front.ppm",
-            "./docs/assets/textures/skyboxes/miramar_y_up/back.ppm"
+            "./docs/assets/textures/skyboxes/miramar_y_up/left.png",
+            "./docs/assets/textures/skyboxes/miramar_y_up/right.png",
+            "./docs/assets/textures/skyboxes/miramar_y_up/down.png",
+            "./docs/assets/textures/skyboxes/miramar_y_up/up.png",
+            "./docs/assets/textures/skyboxes/miramar_y_up/front.png",
+            "./docs/assets/textures/skyboxes/miramar_y_up/back.png"
         ))
     }
 }

--- a/src/raytracer/compositor/colorrgba.rs
+++ b/src/raytracer/compositor/colorrgba.rs
@@ -80,6 +80,11 @@ impl ColorRGBA<u8> {
 // How do we implement this more generally so that we may have ColorRGBA<f64>
 impl<T: Channel> ColorRGBA<T> {
     #[allow(dead_code)]
+    pub fn new_rgba(r: T, g: T, b: T, a: T) -> ColorRGBA<T> {
+        ColorRGBA { r: r, g: g, b: b, a: a }
+    }
+
+    #[allow(dead_code)]
     pub fn new_rgb(r: T, g: T, b: T) -> ColorRGBA<T> {
         ColorRGBA { r: r, g: g, b: b, a: Channel::max_value() }
     }

--- a/src/raytracer/compositor/colorrgba.rs
+++ b/src/raytracer/compositor/colorrgba.rs
@@ -74,23 +74,11 @@ impl ColorRGBA<u8> {
             clamp((g * max_color as f64).round() as i32, min_color as i32, max_color as i32) as u8,
             clamp((b * max_color as f64).round() as i32, min_color as i32, max_color as i32) as u8)
     }
-
-    pub fn from_packed_rgba(color: u32) -> ColorRGBA<u8> {
-        let r = ((color >> 24) & 0xFF) as u8;
-        let g = ((color >> 16) & 0xFF) as u8;
-        let b = ((color >>  8) & 0xFF) as u8;
-        let a = ((color >>  0) & 0xFF) as u8;
-        ColorRGBA { r: r, g: g, b: b, a: a }
-    }
 }
 
 // Maybe later?: ColorRGBA<f64>.quantize() -> ColorRGBA<uint>
 // How do we implement this more generally so that we may have ColorRGBA<f64>
 impl<T: Channel> ColorRGBA<T> {
-    pub fn new_rgba(r: T, g: T, b: T, a: T) -> ColorRGBA<T> {
-        ColorRGBA { r: r, g: g, b: b, a: a }
-    }
-
     #[allow(dead_code)]
     pub fn new_rgb(r: T, g: T, b: T) -> ColorRGBA<T> {
         ColorRGBA { r: r, g: g, b: b, a: Channel::max_value() }

--- a/src/raytracer/compositor/surface.rs
+++ b/src/raytracer/compositor/surface.rs
@@ -4,6 +4,16 @@ use std::ops::{Index, IndexMut};
 
 use raytracer::compositor::{ColorRGBA, SurfaceFactory};
 
+pub struct IterPixelMut<'a, T: 'a>(::std::slice::IterMut<'a, ColorRGBA<T>>);
+
+impl<'a, T> Iterator for IterPixelMut<'a, T> where T: 'a {
+    type Item = &'a mut ColorRGBA<T>;
+
+    fn next(&mut self) -> Option<&'a mut ColorRGBA<T>> {
+        self.0.next()
+    }
+}
+
 #[derive(Clone)]
 pub struct Surface {
     pub width: usize,
@@ -97,6 +107,10 @@ impl Surface {
             panic!("`y` out of bounds (0 <= {} < {}", y, self.height);
         }
         self.width * y + x
+    }
+
+    pub fn iter_pixels_mut<'a>(&'a mut self) -> IterPixelMut<'a, u8> {
+        IterPixelMut(self.buffer.iter_mut())
     }
 }
 


### PR DESCRIPTION
No longer requires conversion to ppm

Adds a dependency on servo's PNG libpng binding.