### PR TITLE
Rust 1.5 has stabilised slice_splits

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(slice_splits)]
 #![deny(unused_imports)]
 
 extern crate image;


### PR DESCRIPTION
We do not depend on any feature flags anymore, so this closes #34